### PR TITLE
Generalize external attributes to allow custom targets

### DIFF
--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -585,7 +585,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         };
         if !MODULE
             .get_or_init(|| Regex::new("^[@a-zA-Z0-9\\./:_-]+$").expect("regex"))
-            .is_match(&module)
+            .is_match(module)
         {
             self.errors.push(Error::InvalidExternalJavascriptModule {
                 location,
@@ -595,7 +595,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         }
         if !FUNCTION
             .get_or_init(|| Regex::new("^[a-zA-Z_][a-zA-Z0-9_]*$").expect("regex"))
-            .is_match(&function)
+            .is_match(function)
         {
             self.errors.push(Error::InvalidExternalJavascriptFunction {
                 location,

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -489,8 +489,7 @@ pub struct Function<T, Expr> {
     pub return_annotation: Option<TypeAst>,
     pub return_type: T,
     pub documentation: Option<EcoString>,
-    pub external_erlang: Option<External>,
-    pub external_javascript: Option<External>,
+    pub externals: Vec<External>,
     pub implementations: Implementations,
 }
 
@@ -500,6 +499,14 @@ pub type UntypedFunction = Function<(), UntypedExpr>;
 impl<T, E> Function<T, E> {
     fn full_location(&self) -> SrcSpan {
         SrcSpan::new(self.location.start, self.end_position)
+    }
+
+    pub fn external_for(&self, target: Target) -> Option<&External> {
+        self.externals.iter().find(|e| e.target == target)
+    }
+
+    pub fn has_external_for(&self, target: Target) -> bool {
+        self.externals.iter().any(|e| e.target == target)
     }
 }
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -489,8 +489,8 @@ pub struct Function<T, Expr> {
     pub return_annotation: Option<TypeAst>,
     pub return_type: T,
     pub documentation: Option<EcoString>,
-    pub external_erlang: Option<(EcoString, EcoString)>,
-    pub external_javascript: Option<(EcoString, EcoString)>,
+    pub external_erlang: Option<External>,
+    pub external_javascript: Option<External>,
     pub implementations: Implementations,
 }
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -454,6 +454,20 @@ impl Publicity {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// An external function spec.
+///
+/// # Example(s)
+///
+/// ```gleam
+/// @external(erlang, "wibble", "wobble")
+/// ```
+pub struct External {
+    pub target: Target,
+    pub module: EcoString,
+    pub function: EcoString,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// A function definition
 ///
 /// # Example(s)

--- a/compiler-core/src/call_graph/into_dependency_order_tests.rs
+++ b/compiler-core/src/call_graph/into_dependency_order_tests.rs
@@ -35,8 +35,7 @@ fn parse_and_order(
             end_position: src.len() as u32,
             return_type: (),
             documentation: None,
-            external_erlang: None,
-            external_javascript: None,
+            externals: vec![],
             implementations: Implementations {
                 gleam: true,
                 uses_erlang_externals: true,

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -361,7 +361,7 @@ fn module_function<'a>(
 ) -> Option<Document<'a>> {
     // Private external functions don't need to render anything, the underlying
     // Erlang implementation is used directly at the call site.
-    if function.external_erlang.is_some() && function.publicity.is_private() {
+    if function.has_external_for(Target::Erlang) && function.publicity.is_private() {
         return None;
     }
 
@@ -386,8 +386,7 @@ fn module_function<'a>(
     let arguments = fun_args(&function.arguments, &mut env);
 
     let body = function
-        .external_erlang
-        .as_ref()
+        .external_for(Target::Erlang)
         .map(
             |External {
                  module, function, ..

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -388,7 +388,11 @@ fn module_function<'a>(
     let body = function
         .external_erlang
         .as_ref()
-        .map(|(module, function)| docvec![atom(module), ":", atom(function), arguments.clone()])
+        .map(
+            |External {
+                 module, function, ..
+             }| docvec![atom(module), ":", atom(function), arguments.clone()],
+        )
         .unwrap_or_else(|| statement_sequence(&function.body, &mut env));
 
     let doc = spec

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -735,11 +735,15 @@ impl<'comments> Formatter<'comments> {
             docvec!["@external(", t, ", \"", m, "\", \"", f, "\")", line()]
         };
         let attributes = match function.external_erlang.as_ref() {
-            Some((m, f)) => attributes.append(external("erlang", m, f)),
+            Some(External {
+                module, function, ..
+            }) => attributes.append(external("erlang", module, function)),
             None => attributes,
         };
         let attributes = match function.external_javascript.as_ref() {
-            Some((m, f)) => attributes.append(external("javascript", m, f)),
+            Some(External {
+                module, function, ..
+            }) => attributes.append(external("javascript", module, function)),
             None => attributes,
         };
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -734,13 +734,13 @@ impl<'comments> Formatter<'comments> {
         let external = |t: &'static str, m: &'a str, f: &'a str| {
             docvec!["@external(", t, ", \"", m, "\", \"", f, "\")", line()]
         };
-        let attributes = match function.external_erlang.as_ref() {
+        let attributes = match function.external_for(Target::Erlang) {
             Some(External {
                 module, function, ..
             }) => attributes.append(external("erlang", module, function)),
             None => attributes,
         };
-        let attributes = match function.external_javascript.as_ref() {
+        let attributes = match function.external_for(Target::JavaScript) {
             Some(External {
                 module, function, ..
             }) => attributes.append(external("javascript", module, function)),

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -227,7 +227,7 @@ impl<'a> Generator<'a> {
             Definition::Function(function) => {
                 // If there's an external JavaScript implementation then it will be imported,
                 // so we don't need to generate a function definition.
-                if function.external_javascript.is_some() {
+                if function.has_external_for(Target::JavaScript) {
                     return None;
                 }
 
@@ -352,18 +352,23 @@ impl<'a> Generator<'a> {
                 Definition::Function(Function {
                     name,
                     publicity,
-                    external_javascript:
-                        Some(External {
-                            module, function, ..
-                        }),
+                    externals,
+                    // external_javascript:
+                    //     Some(External {
+                    //         module, function, ..
+                    //     }),
                     ..
-                }) => {
+                }) if externals.iter().any(|e| e.target == Target::JavaScript) => {
+                    let external_javascript = externals
+                        .iter()
+                        .find(|e| e.target == Target::JavaScript)
+                        .unwrap();
                     self.register_external_function(
                         &mut imports,
                         *publicity,
                         name,
-                        module,
-                        function,
+                        &external_javascript.module,
+                        &external_javascript.function,
                     );
                 }
 

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -353,16 +353,12 @@ impl<'a> Generator<'a> {
                     name,
                     publicity,
                     externals,
-                    // external_javascript:
-                    //     Some(External {
-                    //         module, function, ..
-                    //     }),
                     ..
                 }) if externals.iter().any(|e| e.target == Target::JavaScript) => {
                     let external_javascript = externals
                         .iter()
                         .find(|e| e.target == Target::JavaScript)
-                        .unwrap();
+                        .expect("we know this is Some because we just checked");
                     self.register_external_function(
                         &mut imports,
                         *publicity,

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -352,7 +352,10 @@ impl<'a> Generator<'a> {
                 Definition::Function(Function {
                     name,
                     publicity,
-                    external_javascript: Some((module, function)),
+                    external_javascript:
+                        Some(External {
+                            module, function, ..
+                        }),
                     ..
                 }) => {
                     self.register_external_function(

--- a/compiler-core/src/package_interface.rs
+++ b/compiler-core/src/package_interface.rs
@@ -494,8 +494,7 @@ impl ModuleInterface {
                     end_position: _,
                     body: _,
                     return_annotation: _,
-                    external_erlang: _,
-                    external_javascript: _,
+                    externals: _,
                 }) => {
                     let mut id_map = IdMap::new();
                     let _ = functions.insert(

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -129,16 +129,8 @@ impl Attributes {
         self.externals.iter().any(|v| v.target == target)
     }
 
-    fn take(&mut self, target: Target) -> Option<External> {
-        match self
-            .externals
-            .iter()
-            .enumerate()
-            .find(|(_, v)| v.target == target)
-        {
-            None => None,
-            Some((idx, _)) => self.externals.drain(idx..=idx).next(),
-        }
+    fn take_externals(&mut self) -> Vec<External> {
+        self.externals.drain(0..).collect()
     }
 }
 
@@ -1717,8 +1709,7 @@ where
             return_type: (),
             return_annotation,
             deprecation: std::mem::take(&mut attributes.deprecated),
-            external_erlang: attributes.take(Target::Erlang),
-            external_javascript: attributes.take(Target::JavaScript),
+            externals: attributes.take_externals(),
             implementations: Implementations {
                 gleam: true,
                 can_run_on_erlang: true,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -57,13 +57,13 @@ mod token;
 use crate::analyse::Inferred;
 use crate::ast::{
     Arg, ArgNames, AssignName, Assignment, AssignmentKind, BinOp, BitArrayOption, BitArraySegment,
-    CallArg, Clause, ClauseGuard, Constant, CustomType, Definition, Function, HasLocation, Import,
-    Module, ModuleConstant, Pattern, Publicity, RecordConstructor, RecordConstructorArg,
-    RecordUpdateSpread, SrcSpan, Statement, TargetedDefinition, TodoKind, TypeAlias, TypeAst,
-    TypeAstConstructor, TypeAstFn, TypeAstHole, TypeAstTuple, TypeAstVar, UnqualifiedImport,
-    UntypedArg, UntypedClause, UntypedClauseGuard, UntypedConstant, UntypedDefinition, UntypedExpr,
-    UntypedModule, UntypedPattern, UntypedRecordUpdateArg, UntypedStatement, Use, UseAssignment,
-    CAPTURE_VARIABLE,
+    CallArg, Clause, ClauseGuard, Constant, CustomType, Definition, External, Function,
+    HasLocation, Import, Module, ModuleConstant, Pattern, Publicity, RecordConstructor,
+    RecordConstructorArg, RecordUpdateSpread, SrcSpan, Statement, TargetedDefinition, TodoKind,
+    TypeAlias, TypeAst, TypeAstConstructor, TypeAstFn, TypeAstHole, TypeAstTuple, TypeAstVar,
+    UnqualifiedImport, UntypedArg, UntypedClause, UntypedClauseGuard, UntypedConstant,
+    UntypedDefinition, UntypedExpr, UntypedModule, UntypedPattern, UntypedRecordUpdateArg,
+    UntypedStatement, Use, UseAssignment, CAPTURE_VARIABLE,
 };
 use crate::build::Target;
 use crate::parse::extra::ModuleExtra;
@@ -110,13 +110,6 @@ enum InternalAttribute {
     #[default]
     Missing,
     Present(SrcSpan),
-}
-
-#[derive(Debug)]
-struct External {
-    target: Target,
-    module: EcoString,
-    function: EcoString,
 }
 
 #[derive(Debug, Default)]

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1717,12 +1717,8 @@ where
             return_type: (),
             return_annotation,
             deprecation: std::mem::take(&mut attributes.deprecated),
-            external_erlang: attributes
-                .take(Target::Erlang)
-                .map(|ext| (ext.module, ext.function)),
-            external_javascript: attributes
-                .take(Target::JavaScript)
-                .map(|ext| (ext.module, ext.function)),
+            external_erlang: attributes.take(Target::Erlang),
+            external_javascript: attributes.take(Target::JavaScript),
             implementations: Implementations {
                 gleam: true,
                 can_run_on_erlang: true,


### PR DESCRIPTION
Instead of just erlang and javascript, let's modify the machinery to start to allow "custom" external targets. This PR specifically removes `external_erlang` and `external_javascript` from the AST node, then fixes anything that needs fixing as a result.